### PR TITLE
Add location

### DIFF
--- a/metacatalog_api/core.py
+++ b/metacatalog_api/core.py
@@ -108,6 +108,7 @@ def variables(id: int = None, only_available: bool = False, offset: int = None, 
     
     return variables
 
+
 def add_entry(flat_dict: dict) -> Metadata:
     # get the variable
     # TODO: put this into the server, as this is due to the FORM. the core package should use the payload model

--- a/metacatalog_api/server.py
+++ b/metacatalog_api/server.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse
 from pydantic_geojson import FeatureCollectionModel
 
 from metacatalog_api import core
+from metacatalog_api.views import editing_tools
 
 logger = logging.getLogger('uvicorn.error')
 
@@ -192,6 +193,9 @@ def get_variables(request: Request, fmt: FMT = None, offset: int = None, limit: 
 def new_details(request: Request):
     return templates.TemplateResponse(request=request, name="details.html", context={})
 
+
+# register the editing tools
+app.include_router(editing_tools.edit_router, prefix='/utils')
 
 if __name__ == "__main__":
     import uvicorn

--- a/metacatalog_api/templates/add_entry.html
+++ b/metacatalog_api/templates/add_entry.html
@@ -34,6 +34,22 @@
     </div>
 
     <div x-data="{open: false}">
+        <div class="flex justify-between items-center p-4 bg-gray-100 border-b border-gray-300 cursor-pointer" @click="open = !open;window.dispatchEvent(new Event('resize'));">
+            <h2 class="text-lg font-medium text-gray-700">Location</h2>
+            <svg class="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+        </div>
+        <div class="flex flex-col space-y-4 p-4" x-show="open" x-collapse>
+            <div class="flex flex-col space-y-2">
+                <div class="w-full h-96 border border-gray-300 rounded-md">
+                    <div hx-get="/utils/leaflet_draw.html?embedded=true&view-inputs" hx-trigger="load" hx-swap="outerHTML"></div>
+                </div>
+            </div>
+    </div>
+
+
+    <div x-data="{open: false}">
         <div class="flex justify-between items-center p-4 bg-gray-100 border-b border-gray-300 cursor-pointer" @click="open = !open">
             <h2 class="text-lg font-medium text-gray-700">License</h2>
             <svg class="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -69,10 +85,7 @@
         <button type="submit" class="px-4 py-4 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
             Save Entry
         </button>
-    </div>
-
-
-    
+    </div>    
 
 </form>
 
@@ -81,3 +94,8 @@
 <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
 <script src="//unpkg.com/alpinejs" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/snowball@0.3.1/stemmer/lib/Snowball.min.js"></script>
+<!-- leaflet -->
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<script src="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.min.css" rel="stylesheet">

--- a/metacatalog_api/templates/leaflet_draw.html
+++ b/metacatalog_api/templates/leaflet_draw.html
@@ -1,0 +1,109 @@
+{% set embedded = request.query_params.get('embedded') == 'true' %}
+{% set view_inputs = request.query_params.get('view-inputs') is not none %} 
+{% set geom = request.query_params.get('geom', 'marker') %}
+{% if not embedded %}
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<script src="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/leaflet-draw@1.0.4/dist/leaflet.draw.min.css" rel="stylesheet">
+{% endif %}
+
+<div class="flex flex-col h-full w-full">
+    <div id="map" class="flex-grow"></div>
+
+    {% if view_inputs %}
+        <div class="flex flex-row gap-2 p-2">
+            <input id="location_lon" type="number" step="0.01" min="-180" max="180" name="location.lon" placeholder="Longitude" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
+            <input id="location_lat" type="number" step="0.01" min="-90" max="90" name="location.lat" placeholder="Latitude" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
+        </div>
+    {% else %}
+        <input id="location_lon" type="hidden" name="location.lon" value="">
+        <input id="location_lat" type="hidden" name="location.lat" value="">
+    {% endif %}
+</div>
+
+<script>
+    var map = L.map('map').setView([51.505, -0.09], 10);
+    // make sure to always only have one marker
+    var currentMarker;
+
+    var OpenTopoMap = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+        maxZoom: 17,
+        attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+    }).addTo(map);
+
+    var drawnItems = new L.FeatureGroup();
+    map.addLayer(drawnItems);
+
+    var drawControl = new L.Control.Draw({
+        position: 'topleft',
+        draw: {
+            marker: true,
+            circle: false,
+            rectangle: false,
+            circlemarker: false,
+            polygon: false,
+            polyline: false
+        },
+        edit: {
+            featureGroup: drawnItems,
+            remove: true
+        }
+    });
+    map.addControl(drawControl);
+
+    // this is not really working
+    L.drawLocal.draw.toolbar.buttons.marker = 'Place a marker for the Metadata Entry';
+
+    // event handler for creating a new marker
+    map.on(L.Draw.Event.CREATED, function (event) {
+        var layer = event.layer;
+        if (currentMarker) {
+            drawnItems.removeLayer(currentMarker);
+        }
+        currentMarker = layer;
+        drawnItems.addLayer(currentMarker);
+        updateInputFields(currentMarker.getLatLng().lat, currentMarker.getLatLng().lng);
+    });
+
+    // event handler for editing a marker
+    map.on(L.Draw.Event.EDITED, function (event) {
+        updateInputFields(currentMarker.getLatLng().lat, currentMarker.getLatLng().lng);
+    });
+
+    // function to change the input fields
+    function updateInputFields(lat, lng) {
+        document.getElementById('location_lat').value = lat;
+        document.getElementById('location_lon').value = lng;
+    }
+
+    // function to change the marker
+    function updateMarker(lat, lng) {
+        var newLatLng = new L.LatLng(lat, lng);
+        if (currentMarker) {
+            currentMarker.setLatLng(newLatLng);
+        } else {
+            currentMarker = L.marker(newLatLng).addTo(drawnItems);
+        }
+        map.panTo(newLatLng);
+    }
+
+    // event listener for the longitude input
+    document.getElementById('location_lon').addEventListener('input', function() {
+        updateMarker(parseFloat(document.getElementById('location_lat').value), parseFloat(this.value));
+    });
+
+    // event listener for the latitude input
+    document.getElementById('location_lat').addEventListener('input', function() {
+        updateMarker(parseFloat(this.value), parseFloat(document.getElementById('location_lon').value));
+    });
+
+    // after the map has finished loading, emit the resize event of the window
+    // otherwise leaflet is not aware of the current container size
+    map.whenReady(function () {
+        setTimeout(function () {
+            window.dispatchEvent(new Event('resize'));
+        }, 50);
+    })
+</script>

--- a/metacatalog_api/templates/leaflet_draw.html
+++ b/metacatalog_api/templates/leaflet_draw.html
@@ -14,8 +14,30 @@
 
     {% if view_inputs %}
         <div class="flex flex-row gap-2 p-2">
-            <input id="location_lon" type="number" step="0.01" min="-180" max="180" name="location.lon" placeholder="Longitude" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
-            <input id="location_lat" type="number" step="0.01" min="-90" max="90" name="location.lat" placeholder="Latitude" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
+            <input id="location_lon" 
+                   type="number" 
+                   step="0.01" 
+                   min="-180" 
+                   max="180" 
+                   name="location.lon" 
+                   placeholder="Longitude" 
+                   aria-label="Longitude coordinate"
+                   aria-describedby="lon-error"
+                   pattern="-?([0-9]*[.])?[0-9]+"
+                   class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
+            <span id="lon-error" class="hidden text-red-500 text-sm">Please enter a valid longitude (-180 to 180)</span>
+            <input id="location_lat" 
+                   type="number" 
+                   step="0.01" 
+                   min="-90" 
+                   max="90" 
+                   name="location.lat" 
+                   placeholder="Latitude" 
+                   aria-label="Latitude coordinate"
+                   aria-describedby="lat-error"
+                   pattern="-?([0-9]*[.])?[0-9]+"
+                   class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500">
+            <span id="lat-error" class="hidden text-red-500 text-sm">Please enter a valid latitude (-90 to 90)</span>
         </div>
     {% else %}
         <input id="location_lon" type="hidden" name="location.lon" value="">

--- a/metacatalog_api/templates/leaflet_draw.html
+++ b/metacatalog_api/templates/leaflet_draw.html
@@ -111,14 +111,24 @@
         map.panTo(newLatLng);
     }
 
-    // event listener for the longitude input
+    // Enhanced input handlers with validation
+    function validateAndUpdateMarker(lat, lon) {
+        if (isNaN(lat) || isNaN(lon)) return;
+        if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return;
+        updateMarker(lat, lon);
+    }
+
+    // Event listeners without debounce
     document.getElementById('location_lon').addEventListener('input', function() {
-        updateMarker(parseFloat(document.getElementById('location_lat').value), parseFloat(this.value));
+        const lon = parseFloat(this.value);
+        const lat = parseFloat(document.getElementById('location_lat').value);
+        validateAndUpdateMarker(lat, lon);
     });
 
-    // event listener for the latitude input
     document.getElementById('location_lat').addEventListener('input', function() {
-        updateMarker(parseFloat(this.value), parseFloat(document.getElementById('location_lon').value));
+        const lat = parseFloat(this.value);
+        const lon = parseFloat(document.getElementById('location_lon').value);
+        validateAndUpdateMarker(lat, lon);
     });
 
     // after the map has finished loading, emit the resize event of the window

--- a/metacatalog_api/utils.py
+++ b/metacatalog_api/utils.py
@@ -114,6 +114,12 @@ def metadata_payload_to_model(payload: dict) -> MetadataPayload:
     author = Author(**payload['authors'][0])
     authors = [Author(**a) for a in payload['authors'][1:]]
 
+    # extract the location
+    if 'location' in payload:
+        location = f"POINT ({payload['location']['lon']} {payload['location']['lat']})"
+    else:
+        location = 'NULL'
+
     meta = MetadataPayload(
         title=payload['title'],
         abstract=payload['abstract'],
@@ -122,7 +128,7 @@ def metadata_payload_to_model(payload: dict) -> MetadataPayload:
         license=license,
         is_partial=False,
         comment=payload.get('comment'),
-        location=payload.get('location'),
+        location=location,
         variable=variable,
         citation=payload.get('citation'),
         embargo=False,

--- a/metacatalog_api/utils.py
+++ b/metacatalog_api/utils.py
@@ -115,10 +115,24 @@ def metadata_payload_to_model(payload: dict) -> MetadataPayload:
     authors = [Author(**a) for a in payload['authors'][1:]]
 
     # extract the location
+         # extract the location
     if 'location' in payload:
-        location = f"POINT ({payload['location']['lon']} {payload['location']['lat']})"
+        # Validate coordinates exist and are numeric
+        loc = payload['location']
+        if not all(k in loc for k in ('lon', 'lat')):
+            raise ValueError("Location must contain 'lon' and 'lat' coordinates")
+        try:
+            lon = float(loc['lon'])
+            lat = float(loc['lat'])
+            # Basic coordinate validation
+            if not (-180 <= lon <= 180 and -90 <= lat <= 90):
+                raise ValueError("Invalid coordinate values")
+        except (ValueError, TypeError):
+            raise ValueError("Coordinates must be valid numbers")
+        # Use parameterized format to prevent SQL injection
+        location = f"POINT ({lon:f} {lat:f})"
     else:
-        location = 'NULL'
+        location = 'NULL'   
 
     meta = MetadataPayload(
         title=payload['title'],

--- a/metacatalog_api/views/editing_tools.py
+++ b/metacatalog_api/views/editing_tools.py
@@ -1,0 +1,20 @@
+"""
+This module contains extra views that are only helpful if running the HTML version
+of Metacatalog API. These views are rendered as a FastAPI blueprint and can be loaded
+by any main template to make editing easier for the user.
+"""
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.templating import Jinja2Templates
+
+# initialize the router
+edit_router = APIRouter()
+
+# initialize the templates
+templates = Jinja2Templates(directory=Path(__file__).parent.parent / "templates")
+
+
+@edit_router.get("/leaflet_draw.html")
+def leaflet_draw(request: Request):
+    return templates.TemplateResponse(request=request, name="leaflet_draw.html", context={})


### PR DESCRIPTION
This PR adds a Leaflet map to the `/entries/new.html` route to let the user add the Metadata entry location over a map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new "Location" section in the entry form, allowing users to interactively input geographic coordinates using a map interface.
	- Added a new module for editing tools, enhancing user capabilities within the Metacatalog API.
	- Implemented a new function to add entries to the database, improving data management.

- **Enhancements**
	- Improved handling of location data in metadata entries to ensure consistent formatting and validation.

- **Bug Fixes**
	- Resolved issues related to displaying map inputs based on user preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->