### PR TITLE
Path updates

### DIFF
--- a/metacatalog_api/core.py
+++ b/metacatalog_api/core.py
@@ -128,6 +128,7 @@ def authors(id: int = None, entry_id: int = None, search: str = None, name: str 
     
     return authors
 
+
 def author(id: int = None, name: str = None, search: str = None) -> models.Author | None:
     with connect() as session:
         if id is not None:
@@ -148,7 +149,7 @@ def variables(id: int = None, only_available: bool = False, offset: int = None, 
         if only_available:
             variables = db.get_available_variables(session, limit=limit, offset=offset)
         elif id is not None:
-            variables = [db.get_variable_by_id(session, id=id)]
+            variables = db.get_variable_by_id(session, id=id)
         else:
             variables = db.get_variables(session, limit=limit, offset=offset)
     
@@ -170,6 +171,7 @@ def add_author(payload: models.AuthorCreate, no_duplicates: bool = True) -> mode
     
     return author
 
+
 def add_entry(payload: models.EntryCreate, author_duplicates: bool = False) -> models.Metadata:
     # add the entry
     with connect() as session:
@@ -180,6 +182,7 @@ def add_entry(payload: models.EntryCreate, author_duplicates: bool = False) -> m
             entry = db.add_datasource(session, entry_id=entry.id, datasource=payload.datasource)
         session.commit()
     return entry
+
 
 def add_datasource(entry_id: int, payload: models.DatasourceCreate) -> models.Metadata:
     with connect() as session:

--- a/metacatalog_api/db.py
+++ b/metacatalog_api/db.py
@@ -219,7 +219,8 @@ def get_authors(session: Session, search: str = None, exclude_ids: list[int] = N
     authors = session.exec(query).all()
 
     return [models.Author.model_validate(author) for author in authors]
- 
+
+
 def get_authors_by_name(session: Session, name: str, limit: int = None, offset: int = None) -> list[models.Author]:
     if '*' in name:
         name = name.replace('*', '%')
@@ -235,6 +236,7 @@ def get_authors_by_name(session: Session, name: str, limit: int = None, offset: 
 
     return [models.Author.model_validate(author) for author in authors]
 
+
 def get_author_by_name(session: Session, name: str, strict: bool = False) -> models.Author:
     authors = get_authors_by_name(session, name)
     if len(authors) == 0:
@@ -243,6 +245,7 @@ def get_author_by_name(session: Session, name: str, strict: bool = False) -> mod
         raise RuntimeError(f"More than one author found for name {name}")
     else:
         return authors[0]
+
 
 def create_or_get_author(session: Session, author: models.AuthorCreate) -> models.Author:
     sql = select(models.PersonTable).where(
@@ -259,6 +262,7 @@ def create_or_get_author(session: Session, author: models.AuthorCreate) -> model
         session.refresh(author)
     return models.Author.model_validate(author)
 
+
 def add_author(session: Session, author: models.AuthorCreate) -> models.Author:
     author = models.PersonTable.model_validate(author)
     
@@ -267,6 +271,7 @@ def add_author(session: Session, author: models.AuthorCreate) -> models.Author:
     session.refresh(author)
 
     return models.Author.model_validate(author) 
+
 
 def get_authors_by_entry(session: Session, entry_id: int) -> list[models.Author]:
     query = (
@@ -355,11 +360,6 @@ def get_datatypes(session: Session, id: int = None) -> list[models.DatasourceTyp
         types = session.exec(select(models.DatasourceTypeTable)).all()
 
         return [models.DatasourceTypeBase.model_validate(type_) for type_ in types]
-
-
-# def get_datasource_by_id(session: Cursor, id: int) -> models.Datasource:
-#     # handle the filter
-#     raise NotImplementedError
 
 
 def add_entry(session: Session, payload: models.EntryCreate, author_duplicates: bool = False) -> models.Metadata:

--- a/metacatalog_api/router/api/create.py
+++ b/metacatalog_api/router/api/create.py
@@ -24,3 +24,8 @@ def add_author(payload: models.AuthorCreate, no_duplicates: bool = True) -> mode
     """
     author = core.add_author(payload, no_duplicates=no_duplicates)
     return author
+
+@create_router.post('/group')
+def add_group(payload: models.EntryGroupCreate) -> models.EntryGroup:
+    group = core.add_group(payload=payload)
+    return group

--- a/metacatalog_api/router/api/read.py
+++ b/metacatalog_api/router/api/read.py
@@ -3,6 +3,7 @@ from fastapi.exceptions import HTTPException
 from pydantic_geojson import FeatureCollectionModel
 
 from metacatalog_api import core
+from metacatalog_api import models
 read_router = APIRouter()
 
 
@@ -100,3 +101,37 @@ def get_variable(id: int):
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
     return variable
+
+@read_router.get('/group-types')
+@read_router.get('/group-types.json')
+def get_group_types():
+    try:
+        group_types = core.group_types()
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return group_types
+
+
+@read_router.get('/groups')
+@read_router.get('/groups.json')
+def get_groups(title: str = None, description: str = None, type: str = None, limit: int = None, offset: int = None) -> list[models.EntryGroup]:
+    try:
+        groups = core.groups(title=title, description=description, type=type, with_metadata=False, limit=limit, offset=offset)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    
+    return groups
+
+
+@read_router.get('/groups/{group_id}')
+@read_router.get('/groups/{group_id}.json')
+def get_group(group_id) -> models.EntryGroupWithMetadata:
+    try:
+        group = core.groups(id=group_id, with_metadata=True)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    if group is None:
+        raise HTTPException(status_code=404, detail=f"Group of id {group_id} was not found.")
+
+    return group

--- a/metacatalog_api/router/api/read.py
+++ b/metacatalog_api/router/api/read.py
@@ -36,6 +36,7 @@ def get_entry(id: int):
         raise HTTPException(status_code=404, detail=f"Entry of <ID={id}> not found")
     return entries[0]
 
+
 @read_router.get('/licenses')
 @read_router.get('/licenses.json')
 def get_licenses(license_id: int | None = None):
@@ -83,10 +84,19 @@ def get_author_by_name(id: int = None, name: str = None, search: str = None):
 
 @read_router.get('/variables')
 @read_router.get('/variables.json')
-def get_variables(offset: int = None, limit: int = None):
+def get_variables(only_available: bool = False, offset: int = None, limit: int = None):
     try:
-        variables = core.variables(only_available=False, offset=offset, limit=limit)
+        variables = core.variables(only_available=only_available, offset=offset, limit=limit)
     except Exception as e:
         return HTTPException(status_code=404, detail=str(e))
 
     return variables
+
+@read_router.get('/variable/{id}')
+@read_router.get('/variable/{id}.json')
+def get_variable(id: int):
+    try:
+        variable = core.variables(id=id)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return variable


### PR DESCRIPTION
@AlexDo1 this PR includes the updates to manage Groups through the API. 

It can already also add new groups in place, with a new Entry, without duplicating. You can append a list like 
```python
entry.groups = [2, 3, dict(title="New Group", description="New group added in place", type="Label")]
```

this will add associations for the new entry to the pre-existing groups of id 2 and 3 and create a new 'Label'-type group called 'New Group'.

Currently we don't have very useful group types beside the composite, as 'Label' is not very descriptive. You may suggest new types and also additional fields on a group beside a title and a description. There will also be a database migration changing the type of title and description from character varying to text, I would include your suggestions into that migration.

If you can't think of improvements right away, I can also merge and do the migration in an extra PR.
